### PR TITLE
Add Jest setup and engine unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview --port 4173"
+    "preview": "vite preview --port 4173",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
   "dependencies": {
     "react": "^18.3.1",
@@ -14,6 +15,11 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.1",
-    "vite": "^5.4.0"
+    "vite": "^5.4.0",
+    "jest": "^29.7.0"
+  },
+  "jest": {
+    "testEnvironment": "node",
+    "extensionsToTreatAsEsm": [".js"]
   }
 }

--- a/tests/engine.test.js
+++ b/tests/engine.test.js
@@ -1,0 +1,29 @@
+import { winner, bestMoveTimeboxed, findWinLine } from '../ai/engine.js';
+
+describe('winner', () => {
+  test('detects horizontal win for player 1', () => {
+    const board = [[1], [1], [1], [1], [], [], []];
+    expect(winner(board)).toBe(1);
+  });
+});
+
+describe('findWinLine', () => {
+  test('identifies vertical win line for player -1', () => {
+    const board = [[-1, -1, -1, -1], [], [], [], [], [], []];
+    const line = findWinLine(board);
+    expect(line).toEqual([
+      { r: 2, c: 0 },
+      { r: 3, c: 0 },
+      { r: 4, c: 0 },
+      { r: 5, c: 0 },
+    ]);
+  });
+});
+
+describe('bestMoveTimeboxed', () => {
+  test('chooses winning move within time limit', () => {
+    const board = [[1], [1], [1], [], [], [], []];
+    const result = bestMoveTimeboxed(board, 1, 100);
+    expect(result.best).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
- configure Jest in package.json for ESM testing
- add unit tests covering winner, findWinLine and bestMoveTimeboxed

## Testing
- `npm test` *(fails: Cannot find module '/workspace/MindMatch4/node_modules/jest/bin/jest.js')*


------
https://chatgpt.com/codex/tasks/task_e_68a6fca6377c832982bbb4338516b4ee