### PR TITLE
refactor setup scripts and improve focus outlines

### DIFF
--- a/index.html
+++ b/index.html
@@ -185,13 +185,6 @@
     }
     </script>
 
-    <!-- PWA -->
-    <script>
-      if ("serviceWorker" in navigator) {
-        navigator.serviceWorker.register("/MindMatch4/sw.js");
-      }
-    </script>
-
     <!-- GA4 -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-E18C1B9SE4"></script>
     <script>
@@ -200,39 +193,7 @@
       gtag('js', new Date());
       gtag('config', 'G-E18C1B9SE4');
     </script>
-
-    <!-- Fit 7x6 strictly inside available width/height -->
-    <script>
-      function currentTheme(){
-        const t = localStorage.getItem("mm4_theme") || "auto";
-        document.documentElement.setAttribute("data-theme", t);
-        const sel = document.getElementById("themeSelect");
-        if (sel) sel.value = t;
-      }
-      currentTheme();
-
-      function fitCell(){
-        const gap = 10;          // keep in sync
-        const pagePad = 24;      // left+right page padding
-        const vw = Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
-        const vh = Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
-        const headerH = (document.querySelector('.site-header')?.offsetHeight || 0);
-
-        const availW = vw - pagePad - 2;    // -2 for rounding
-        const availH = vh - headerH - 220;  // headroom for bars
-
-        const cellFromW = Math.floor((availW - gap*6) / 7);
-        const cellFromH = Math.floor((availH - gap*5) / 6);
-        const size = Math.max(26, Math.min(92, Math.min(cellFromW, cellFromH)));
-
-        document.documentElement.style.setProperty('--gap',  gap + 'px');
-        document.documentElement.style.setProperty('--cell', size + 'px');
-      }
-
-      addEventListener('resize', fitCell);
-      addEventListener('orientationchange', fitCell);
-      addEventListener('DOMContentLoaded', fitCell);
-    </script>
+    <script type="module" src="/src/setup.js"></script>
   </head>
 
   <body>
@@ -255,27 +216,5 @@
 
     <!-- Vite entry -->
     <script type="module" src="/src/main.jsx"></script>
-
-    <!-- Wire up title + theme + AI plugin + analytics -->
-    <script type="module">
-      // Title → Home
-      document.querySelector(".site-title")?.addEventListener("click", ()=>{
-        window.dispatchEvent(new CustomEvent("mm4:navigate",{detail:{to:"home"}}));
-      });
-
-      // Theme persistence
-      const setT = (t)=>{ localStorage.setItem("mm4_theme", t); document.documentElement.setAttribute("data-theme", t); };
-      document.getElementById("themeSelect")?.addEventListener("change", (e)=> setT(e.target.value));
-
-      // Ensure AI wiring is present (for Hint)
-      import "./ai/adapter.js";
-      import "./ai/mm4-plugin.js";
-      import "./ai/mm4-plugin-wire.js";
-
-      // Analytics hooks
-      window.addEventListener("mm4:hint",   (e)=> window.gtag && gtag('event','hint_used',{count:e.detail?.best?.length||0}));
-      window.addEventListener("mm4:aimove", (e)=> window.gtag && gtag('event','ai_move',{col:e.detail?.col}));
-      window.addEventListener("mm4:gameend",(e)=> window.gtag && gtag('event','game_end',{outcome:e.detail?.outcome}));
-    </script>
   </body>
 </html>

--- a/src/setup.js
+++ b/src/setup.js
@@ -1,0 +1,54 @@
+import "../ai/adapter.js";
+import "../ai/mm4-plugin.js";
+import "../ai/mm4-plugin-wire.js";
+
+// Apply saved theme immediately
+const savedTheme = localStorage.getItem("mm4_theme") || "auto";
+document.documentElement.setAttribute("data-theme", savedTheme);
+
+function setTheme(t){
+  localStorage.setItem("mm4_theme", t);
+  document.documentElement.setAttribute("data-theme", t);
+}
+
+function fitCell(){
+  const gap = 10;          // keep in sync
+  const pagePad = 24;      // left+right page padding
+  const vw = Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
+  const vh = Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
+  const headerH = (document.querySelector('.site-header')?.offsetHeight || 0);
+
+  const availW = vw - pagePad - 2;    // -2 for rounding
+  const availH = vh - headerH - 220;  // headroom for bars
+
+  const cellFromW = Math.floor((availW - gap*6) / 7);
+  const cellFromH = Math.floor((availH - gap*5) / 6);
+  const size = Math.max(26, Math.min(92, Math.min(cellFromW, cellFromH)));
+
+  document.documentElement.style.setProperty('--gap',  gap + 'px');
+  document.documentElement.style.setProperty('--cell', size + 'px');
+}
+
+window.addEventListener('resize', fitCell);
+window.addEventListener('orientationchange', fitCell);
+window.addEventListener('DOMContentLoaded', () => {
+  fitCell();
+  const sel = document.getElementById("themeSelect");
+  if (sel){
+    sel.value = savedTheme;
+    sel.addEventListener("change", (e)=> setTheme(e.target.value));
+  }
+  document.querySelector(".site-title")?.addEventListener("click", ()=>{
+    window.dispatchEvent(new CustomEvent("mm4:navigate",{detail:{to:"home"}}));
+  });
+});
+
+// Register service worker
+if ("serviceWorker" in navigator) {
+  navigator.serviceWorker.register("/MindMatch4/sw.js");
+}
+
+// Analytics hooks
+window.addEventListener("mm4:hint",   (e)=> window.gtag && gtag('event','hint_used',{count:e.detail?.best?.length||0}));
+window.addEventListener("mm4:aimove", (e)=> window.gtag && gtag('event','ai_move',{col:e.detail?.col}));
+window.addEventListener("mm4:gameend",(e)=> window.gtag && gtag('event','game_end',{outcome:e.detail?.outcome}));

--- a/src/styles.css
+++ b/src/styles.css
@@ -5,6 +5,11 @@
   max-width: min(calc(7 * var(--cell) + 6 * var(--gap) + 32px), 100vw);
 }
 
+:focus-visible {
+  outline: 2px solid var(--blue);
+  outline-offset: 2px;
+}
+
 /* Top bar (in App Home/Game) */
 .topbar{
   display:flex; align-items:center; justify-content:space-between;


### PR DESCRIPTION
## Summary
- move theme, layout, service worker, and analytics setup into new `src/setup.js`
- remove large inline scripts from `index.html` for cleaner structure
- add global `:focus-visible` outline for better keyboard accessibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a73abcb3648329af79adc5237811dd