### PR TITLE
Add React component and AI unit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: Node CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm install --no-audit --no-fund
+      - run: npm test

--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  presets: [
+    ['@babel/preset-env', {targets: {node: 'current'}}],
+    ['@babel/preset-react', {runtime: 'automatic'}],
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -16,9 +16,14 @@
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.1",
     "vite": "^5.4.0",
-    "jest": "^29.7.0"
+    "jest": "^29.7.0",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/jest-dom": "^6.1.5",
+    "babel-jest": "^29.7.0",
+    "@babel/preset-env": "^7.24.1",
+    "@babel/preset-react": "^7.24.1"
   },
   "jest": {
-    "testEnvironment": "node"
+    "testEnvironment": "jsdom"
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -628,3 +628,5 @@ function WinOverlay({line}){
     </div>
   );
 }
+
+export { computeLocalHints, reasonFor };

--- a/tests/App.test.jsx
+++ b/tests/App.test.jsx
@@ -1,0 +1,28 @@
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import App from '../src/App.jsx';
+
+test('navigate and play full local multiplayer game', async () => {
+  render(<App />);
+
+  expect(screen.getByText(/Welcome/)).toBeInTheDocument();
+
+  fireEvent.click(screen.getByText('Local Multiplayer'));
+
+  expect(await screen.findByText('P1 move (Yellow)')).toBeInTheDocument();
+
+  const cols = screen.getAllByRole('columnheader');
+
+  fireEvent.click(cols[0]);
+  fireEvent.click(cols[1]);
+  fireEvent.click(cols[0]);
+  fireEvent.click(cols[1]);
+  fireEvent.click(cols[0]);
+  fireEvent.click(cols[1]);
+  fireEvent.click(cols[0]);
+
+  expect(await screen.findByText('P1 wins!')).toBeInTheDocument();
+
+  fireEvent.click(screen.getByText('Home'));
+  expect(screen.getByText(/Welcome/)).toBeInTheDocument();
+});

--- a/tests/ai.test.js
+++ b/tests/ai.test.js
@@ -1,0 +1,56 @@
+import { computeLocalHints, reasonFor } from '../src/App.jsx';
+import { aiMove } from '../ai/coach.js';
+
+describe('reasonFor', () => {
+  test('identifies winning move', () => {
+    const board = [[1], [1], [1], [], [], [], []];
+    expect(reasonFor(board, 1, 3)).toEqual({ col: 3, tag: 'win', note: 'Winning move' });
+  });
+
+  test('identifies block move', () => {
+    const board = [[-1], [-1], [-1], [], [], [], []];
+    expect(reasonFor(board, 1, 3)).toEqual({ col: 3, tag: 'block', note: 'Block opponent' });
+  });
+});
+
+describe('computeLocalHints', () => {
+  test('returns winning move', () => {
+    const board = [[1], [1], [1], [], [], [], []];
+    expect(computeLocalHints(board, 1)).toEqual({
+      best: [3],
+      note: 'Winning move',
+      reasons: [{ col: 3, tag: 'win', note: 'Winning move' }],
+    });
+  });
+
+  test('returns block move', () => {
+    const board = [[-1], [-1], [-1], [], [], [], []];
+    const hint = computeLocalHints(board, 1);
+    expect(hint.best).toEqual([3]);
+    expect(hint.note).toBe('Block opponent');
+  });
+});
+
+describe('aiMove', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    localStorage.setItem('mm4_skill', JSON.stringify({ rating: 900, games: 0 }));
+    jest.spyOn(Math, 'random').mockReturnValue(0.9);
+  });
+
+  afterEach(() => {
+    Math.random.mockRestore();
+  });
+
+  test('chooses winning move', () => {
+    const board = [[-1], [-1], [-1], [], [], [], []];
+    const move = aiMove(board, -1);
+    expect(move).toBe(3);
+  });
+
+  test('blocks opponent win', () => {
+    const board = [[1], [1], [1], [], [], [], []];
+    const move = aiMove(board, -1);
+    expect(move).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
- install React Testing Library and Jest DOM, configure Babel for JSX
- add navigation and gameplay test for App component
- add unit tests for computeLocalHints, reasonFor, and aiMove
- run tests in CI via npm test

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68a74135553883299fa35ee935c886d8