### PR TITLE
Improve accessibility for MindMatch4 modal and status updates

### DIFF
--- a/src/Modal.jsx
+++ b/src/Modal.jsx
@@ -1,0 +1,54 @@
+import React, { useEffect, useRef } from "react";
+
+export default function Modal({ children, onClose }) {
+  const dialogRef = useRef(null);
+  const lastFocused = useRef(null);
+
+  useEffect(() => {
+    // Save the previously focused element
+    lastFocused.current = document.activeElement;
+    const node = dialogRef.current;
+    if (!node) return;
+
+    // Focus the first focusable element inside the dialog
+    const focusable = node.querySelectorAll(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    first && first.focus();
+
+    function handleKey(e) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose && onClose();
+      } else if (e.key === "Tab") {
+        if (focusable.length === 0) return;
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    }
+
+    node.addEventListener("keydown", handleKey);
+    return () => {
+      node.removeEventListener("keydown", handleKey);
+      // Restore focus when modal unmounts
+      if (lastFocused.current && typeof lastFocused.current.focus === "function") {
+        lastFocused.current.focus();
+      }
+    };
+  }, [onClose]);
+
+  return (
+    <div className="modal" role="dialog" aria-modal="true">
+      <div className="dialog" ref={dialogRef}>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -10,6 +10,18 @@
   outline-offset: 2px;
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 /* Top bar (in App Home/Game) */
 .topbar{
   display:flex; align-items:center; justify-content:space-between;


### PR DESCRIPTION
## Summary
- Add reusable `Modal` component with dialog semantics, focus trapping, and focus return
- Announce status changes via an offscreen `aria-live` region
- Label board columns and controls for clearer screen reader prompts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7413bafd4832994a90519a8c2da4a