### PR TITLE
refactor: use CSS clamp for cell size

### DIFF
--- a/src/setup.js
+++ b/src/setup.js
@@ -10,29 +10,7 @@ function setTheme(t){
   localStorage.setItem("mm4_theme", t);
   document.documentElement.setAttribute("data-theme", t);
 }
-
-function fitCell(){
-  const gap = 10;          // keep in sync
-  const pagePad = 24;      // left+right page padding
-  const vw = Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
-  const vh = Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
-  const headerH = (document.querySelector('.site-header')?.offsetHeight || 0);
-
-  const availW = vw - pagePad - 2;    // -2 for rounding
-  const availH = vh - headerH - 220;  // headroom for bars
-
-  const cellFromW = Math.floor((availW - gap*6) / 7);
-  const cellFromH = Math.floor((availH - gap*5) / 6);
-  const size = Math.max(26, Math.min(92, Math.min(cellFromW, cellFromH)));
-
-  document.documentElement.style.setProperty('--gap',  gap + 'px');
-  document.documentElement.style.setProperty('--cell', size + 'px');
-}
-
-window.addEventListener('resize', fitCell);
-window.addEventListener('orientationchange', fitCell);
 window.addEventListener('DOMContentLoaded', () => {
-  fitCell();
   const sel = document.getElementById("themeSelect");
   if (sel){
     sel.value = savedTheme;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,5 +1,9 @@
 /* Shell & header styles are in index.html (inline for faster paint). This file focuses on app-specific parts. */
 
+:root{
+  --cell: clamp(26px, calc((100vw - 24px - 6*var(--gap))/7), 92px);
+}
+
 .app{
   width: 100%;
   max-width: min(calc(7 * var(--cell) + 6 * var(--gap) + 32px), 100vw);
@@ -36,7 +40,7 @@
   border: 1px solid var(--panel-border);
   border-radius: 14px;
   box-shadow: var(--shadow);
-  width: min(calc(7 * var(--cell) + 6 * var(--gap)), calc(100vw - 24px));
+  width: calc(7 * var(--cell) + 6 * var(--gap));
   max-width: 100%;
 }
 


### PR DESCRIPTION
## Summary
- remove JS-based `fitCell` sizing and related listeners
- compute `--cell` via CSS `clamp()` and simplify board width

## Testing
- `npm test`
- `node - <<'NODE'...` (viewed cell and board sizes for multiple viewport widths)

------
https://chatgpt.com/codex/tasks/task_e_68a7413c496c8329ab434fcb4ec3a476