### PR TITLE
Fix service worker path and confetti color index

### DIFF
--- a/src/setup.js
+++ b/src/setup.js
@@ -23,7 +23,8 @@ window.addEventListener('DOMContentLoaded', () => {
 
 // Register service worker
 if ("serviceWorker" in navigator) {
-  navigator.serviceWorker.register("/MindMatch4/sw.js");
+  const swUrl = new URL("sw.js", import.meta.env.BASE_URL).href;
+  navigator.serviceWorker.register(swUrl);
 }
 
 // Analytics hooks

--- a/src/utils/gameHelpers.js
+++ b/src/utils/gameHelpers.js
@@ -107,7 +107,7 @@ export function fireConfetti(canvas) {
         "#10b981",
         "#3b82f6",
         "#a855f7",
-      ][p.s | 0 % 5];
+      ][(p.s | 0) % 5];
       ctx.fillRect(-p.s / 2, -p.s / 2, p.s, p.s);
       ctx.restore();
     });


### PR DESCRIPTION
## Summary
- Use Vite base URL when registering service worker to work in dev and production
- Correct confetti color indexing so colors cycle properly

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7481dfbec8329826d6abbef9dee75