### PR TITLE
Fix AI engine import path in App component

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
-import * as Engine from "../ai/engine.js"; // adjust path if needed
+import * as Engine from "../../ai/engine.js"; // adjust path to root-level ai folder
 
 /* ============ Board helpers ============ */
 const ROWS = 6, COLS = 7;


### PR DESCRIPTION
## Summary
- correct path to AI engine in App.jsx so Vite can resolve module

## Testing
- `npm test`
- `npm run lint` *(fails: 'gtag' is not defined, 'describe/test/expect' is not defined)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a81cdb248c8329a2072880d9f93314