### PR TITLE
Fix AI engine import path and guard localStorage usage

### DIFF
--- a/ai/rating.js
+++ b/ai/rating.js
@@ -1,7 +1,19 @@
 // ai/rating.js
 const DEFAULT = { rating: 1200, games: 0 };
-export function getSkill(){ return JSON.parse(localStorage.getItem("mm4_skill")||JSON.stringify(DEFAULT)); }
-export function saveSkill(s){ localStorage.setItem("mm4_skill", JSON.stringify(s)); }
+export function getSkill(){
+  try {
+    return JSON.parse(localStorage.getItem("mm4_skill") || JSON.stringify(DEFAULT));
+  } catch (e) {
+    return DEFAULT;
+  }
+}
+export function saveSkill(s){
+  try {
+    localStorage.setItem("mm4_skill", JSON.stringify(s));
+  } catch (e) {
+    // ignore
+  }
+}
 
 // result: 1=AI wins, 0=AI loses, 0.5=draw
 export function updateSkill(result){

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
-import * as Engine from "../ai/engine.js"; // adjust path if needed
+import * as Engine from "../../ai/engine.js"; // adjust path to root-level ai folder
+import { lsGet, lsSet } from "../utils/storage.js";
 
 /* ============ Board helpers ============ */
 const ROWS = 6, COLS = 7;
@@ -156,8 +157,11 @@ export default function App(){
 
 /* ============ Home ============ */
 function Home({onPlayAI,onPlay2P,onDaily}){
-  const [soundOn, setSoundOn] = useState(()=> JSON.parse(localStorage.getItem("mm4_sound_on")||"true"));
-  useEffect(()=>{ SND.toggle(soundOn); localStorage.setItem("mm4_sound_on", JSON.stringify(soundOn)); }, [soundOn]);
+  const [soundOn, setSoundOn] = useState(() => JSON.parse(lsGet("mm4_sound_on", "true")));
+  useEffect(() => {
+    SND.toggle(soundOn);
+    lsSet("mm4_sound_on", JSON.stringify(soundOn));
+  }, [soundOn]);
 
   return (
     <div className="card" style={{margin:"0 auto", maxWidth:520}}>

--- a/src/components/Game.jsx
+++ b/src/components/Game.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from "react";
 import * as Engine from "../../ai/engine.js";
 import Board from "./Board.jsx";
 import ResultModal from "./Modal.jsx";
+import { lsGet, lsSet } from "../utils/storage.js";
 import {
   ROWS,
   COLS,
@@ -29,7 +30,7 @@ export default function Game({ mode, seedDaily, onBack }) {
   const [focusCol, setFocusCol] = useState(3);
   const [cautionCols, setCautionCols] = useState([]);
 
-  const [level, setLevel] = useState(() => localStorage.getItem("mm4_level") || "Auto");
+  const [level, setLevel] = useState(() => lsGet("mm4_level", "Auto"));
   const lockedLevelRef = useRef(level);
   const moves = totalPieces(board);
   useEffect(() => {
@@ -38,13 +39,15 @@ export default function Game({ mode, seedDaily, onBack }) {
 
   const setLevelPersist = (v) => {
     setLevel(v);
-    localStorage.setItem("mm4_level", v);
+    lsSet("mm4_level", v);
   };
 
   const [stats, setStats] = useState(() =>
     JSON.parse(
-      localStorage.getItem("mm4_stats") ||
+      lsGet(
+        "mm4_stats",
         `{"games":0,"wins":0,"losses":0,"draws":0,"streak":0}`
+      )
     )
   );
   const record = (outcomeKey) => {
@@ -60,12 +63,12 @@ export default function Game({ mode, seedDaily, onBack }) {
     } else {
       s.draws++;
     }
-    localStorage.setItem("mm4_stats", JSON.stringify(s));
+    lsSet("mm4_stats", JSON.stringify(s));
     setStats(s);
   };
   const resetStats = () => {
     const s = { games: 0, wins: 0, losses: 0, draws: 0, streak: 0 };
-    localStorage.setItem("mm4_stats", JSON.stringify(s));
+    lsSet("mm4_stats", JSON.stringify(s));
     setStats(s);
   };
 
@@ -73,7 +76,7 @@ export default function Game({ mode, seedDaily, onBack }) {
   const lastSaved = useRef("");
 
   useEffect(() => {
-    const raw = localStorage.getItem("mm4_autosave");
+    const raw = lsGet("mm4_autosave");
     if (!raw) return;
     try {
       const { b, t } = JSON.parse(raw);
@@ -89,7 +92,7 @@ export default function Game({ mode, seedDaily, onBack }) {
   useEffect(() => {
     const snap = JSON.stringify({ b: board, t: turn, m: mode, e: end });
     if (snap !== lastSaved.current) {
-      localStorage.setItem("mm4_autosave", snap);
+      lsSet("mm4_autosave", snap);
       lastSaved.current = snap;
     }
   }, [board, turn, mode, end]);
@@ -238,8 +241,8 @@ export default function Game({ mode, seedDaily, onBack }) {
 
   useEffect(() => {
     const key = "mm4_seen_onboarding";
-    if (localStorage.getItem(key)) return;
-    localStorage.setItem(key, "1");
+    if (lsGet(key)) return;
+    lsSet(key, "1");
     const center = document.querySelector('[data-col="3"]');
     if (center) {
       center.classList.add("onboard-pulse");

--- a/src/setup.js
+++ b/src/setup.js
@@ -1,13 +1,14 @@
 import "../ai/adapter.js";
 import "../ai/mm4-plugin.js";
 import "../ai/mm4-plugin-wire.js";
+import { lsGet, lsSet } from "./utils/storage.js";
 
 // Apply saved theme immediately
-const savedTheme = localStorage.getItem("mm4_theme") || "auto";
+let savedTheme = lsGet("mm4_theme", "auto");
 document.documentElement.setAttribute("data-theme", savedTheme);
 
 function setTheme(t){
-  localStorage.setItem("mm4_theme", t);
+  lsSet("mm4_theme", t);
   document.documentElement.setAttribute("data-theme", t);
 }
 window.addEventListener('DOMContentLoaded', () => {

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -1,0 +1,16 @@
+export function lsGet(key, fallback = null) {
+  try {
+    const v = localStorage.getItem(key);
+    return v === null ? fallback : v;
+  } catch (e) {
+    return fallback;
+  }
+}
+
+export function lsSet(key, value) {
+  try {
+    localStorage.setItem(key, value);
+  } catch (e) {
+    // ignore storage errors (e.g., in private mode)
+  }
+}


### PR DESCRIPTION
## Summary
- correct path to AI engine in App.jsx so Vite can resolve module
- wrap localStorage access in helper functions and use them across the app to avoid crashes when storage is unavailable

## Testing
- `npm test`
- `npm run lint` *(fails: 'gtag' is not defined, no-unused-vars, etc.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a81cdb248c8329a2072880d9f93314