### PR TITLE
Fix static asset paths for deployment subpath

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,11 +21,11 @@
     <!-- Optional if you have a handle: <meta name="twitter:site" content="@YourHandle" /> -->
 
     <!-- Icons resolve under /MindMatch4/ -->
-    <link rel="icon" href="%BASE_URL%favicon.ico" />
-    <link rel="icon" type="image/png" sizes="32x32"  href="%BASE_URL%logo-32.png" />
-    <link rel="icon" type="image/png" sizes="64x64"  href="%BASE_URL%logo-64.png" />
-    <link rel="apple-touch-icon" sizes="192x192" href="%BASE_URL%logo-192.png" />
-    <link rel="apple-touch-icon" sizes="512x512" href="%BASE_URL%logo-512.png" />
+    <link rel="icon" href="/MindMatch4/favicon.ico" />
+    <link rel="icon" type="image/png" sizes="32x32"  href="/MindMatch4/logo-32.png" />
+    <link rel="icon" type="image/png" sizes="64x64"  href="/MindMatch4/logo-64.png" />
+    <link rel="apple-touch-icon" sizes="192x192" href="/MindMatch4/logo-192.png" />
+    <link rel="apple-touch-icon" sizes="512x512" href="/MindMatch4/logo-512.png" />
     <link rel="manifest" href="/MindMatch4/manifest.json" />
 
     <style>


### PR DESCRIPTION
## Summary
- ensure static assets use absolute `/MindMatch4/` paths

## Testing
- `npm test`
- `npm run lint` *(fails: 'describe' is not defined, etc.)*
- `npm run build`
- `python -m http.server 5000` (manual)

------
https://chatgpt.com/codex/tasks/task_e_68c7f0c4a3448329991f9af1c0480a11