### PR TITLE
feat: deep-linkable hash routing for game selection

### DIFF
--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import { SND } from "../utils/gameHelpers.js";
 import {
   AGE_GROUPS, CATEGORIES, SKILL_ICONS,
+  getGameIdFromRoute, getGameRoute,
   filterGames,
 } from "../utils/gameCatalog.js";
 import ProgressBadge from "./ProgressBadge.jsx";
@@ -70,6 +71,17 @@ export default function Home({
   const [query, setQuery] = useState("");
 
   useEffect(() => {
+    const syncPickedFromHash = () => {
+      const match = window.location.hash.match(/^#\/games\/([^/]+)$/);
+      setPicked(match ? getGameIdFromRoute(match[1]) : null);
+    };
+
+    syncPickedFromHash();
+    window.addEventListener("hashchange", syncPickedFromHash);
+    return () => window.removeEventListener("hashchange", syncPickedFromHash);
+  }, []);
+
+  useEffect(() => {
     SND.toggle(soundOn);
     localStorage.setItem("mm4_sound_on", JSON.stringify(soundOn));
   }, [soundOn]);
@@ -98,6 +110,17 @@ export default function Home({
   const selectedModeLabel =
     selectedMode === "ai" ? "Play vs AI" :
     selectedMode === "2p" ? "Local 2P" : "Daily Puzzle";
+
+  const goHome = () => {
+    if (window.location.hash !== "#/home") window.location.hash = "#/home";
+    setPicked(null);
+  };
+
+  const goToGame = (gameId) => {
+    const nextHash = `#/games/${getGameRoute(gameId)}`;
+    if (window.location.hash !== nextHash) window.location.hash = nextHash;
+    setPicked(gameId);
+  };
 
   return (
     <div className={`home${kidsMode ? " home-kids" : ""}`}>
@@ -204,11 +227,12 @@ export default function Home({
 
             <div className="game-picker">
               {filtered.map(g => (
-                <button
+                <a
                   key={g.id}
                   className={`game-pick-card game-pick-card-${g.id}${g.kidFriendly ? " game-pick-kid" : ""}`}
+                  href={`#/games/${getGameRoute(g.id)}`}
                   onMouseEnter={() => SND.hover()}
-                  onClick={() => { SND.select(); setPicked(g.id); }}
+                  onClick={(e) => { e.preventDefault(); SND.select(); goToGame(g.id); }}
                 >
                   <span className="game-pick-icon">{g.icon}</span>
                   <span className="game-pick-name">{g.name}</span>
@@ -227,7 +251,7 @@ export default function Home({
                       );
                     })}
                   </span>
-                </button>
+                  </a>
               ))}
             </div>
           </>
@@ -235,7 +259,7 @@ export default function Home({
 
         {picked === "connect4" && (
           <>
-            <BackBtn onClick={() => setPicked(null)} />
+            <BackBtn onClick={goHome} />
             <h2 className="home-game-title">Connect Four</h2>
             <p className="home-steps">Choose mode and difficulty, then press Play.</p>
             <h3 className="section-label">Mode</h3>
@@ -256,7 +280,7 @@ export default function Home({
 
         {picked === "reversi" && (
           <>
-            <BackBtn onClick={() => setPicked(null)} />
+            <BackBtn onClick={goHome} />
             <h2 className="home-game-title">Reversi</h2>
             <p className="home-steps">Choose mode and difficulty, then press Play.</p>
             <h3 className="section-label">Mode</h3>
@@ -284,7 +308,7 @@ export default function Home({
 
         {picked === "battleship" && (
           <>
-            <BackBtn onClick={() => setPicked(null)} />
+            <BackBtn onClick={goHome} />
             <h2 className="home-game-title">Battleship</h2>
             <p className="home-steps">Choose mode and difficulty, then press Play.</p>
             <h3 className="section-label">Mode</h3>
@@ -312,7 +336,7 @@ export default function Home({
 
         {picked === "gomoku" && (
           <>
-            <BackBtn onClick={() => setPicked(null)} />
+            <BackBtn onClick={goHome} />
             <h2 className="home-game-title">Gomoku</h2>
             <p className="home-steps">Five in a row wins!</p>
             <h3 className="section-label">Mode</h3>
@@ -340,7 +364,7 @@ export default function Home({
 
         {picked === "twenty48" && (
           <>
-            <BackBtn onClick={() => setPicked(null)} />
+            <BackBtn onClick={goHome} />
             <h2 className="home-game-title">2048</h2>
             <p className="home-steps">Swipe (mobile) or arrow keys (desktop) to merge equal tiles.</p>
             <div className="home-howto">
@@ -359,7 +383,7 @@ export default function Home({
 
         {picked === "spatial" && (
           <>
-            <BackBtn onClick={() => setPicked(null)} />
+            <BackBtn onClick={goHome} />
             <h2 className="home-game-title">Shape Fit</h2>
             <p className="home-steps">Rotate and place each block so the silhouette fills perfectly.</p>
             <div className="home-howto">
@@ -378,7 +402,7 @@ export default function Home({
 
         {picked === "memory" && (
           <>
-            <BackBtn onClick={() => setPicked(null)} />
+            <BackBtn onClick={goHome} />
             <h2 className="home-game-title">Memory Match</h2>
             <p className="home-steps">Choose mode and difficulty, then press Play.</p>
             <h3 className="section-label">Mode</h3>
@@ -409,7 +433,7 @@ export default function Home({
 
         {picked === "simon" && (
           <>
-            <BackBtn onClick={() => setPicked(null)} />
+            <BackBtn onClick={goHome} />
             <h2 className="home-game-title">Simon Says</h2>
             <p className="home-steps">Watch the colors light up — then tap them in the same order!</p>
             <div className="home-howto">
@@ -428,7 +452,7 @@ export default function Home({
 
         {picked === "math" && (
           <>
-            <BackBtn onClick={() => setPicked(null)} />
+            <BackBtn onClick={goHome} />
             <h2 className="home-game-title">Math Sprint</h2>
             <p className="home-steps">Solve as many problems as you can in 60 seconds. Streaks earn bonus points!</p>
             <h3 className="section-label">Difficulty</h3>
@@ -450,7 +474,7 @@ export default function Home({
 
         {picked === "word" && (
           <>
-            <BackBtn onClick={() => setPicked(null)} />
+            <BackBtn onClick={goHome} />
             <h2 className="home-game-title">Word Scramble</h2>
             <p className="home-steps">Unscramble letters before time runs out. Builds vocabulary!</p>
             <h3 className="section-label">Difficulty</h3>
@@ -474,7 +498,7 @@ export default function Home({
 
         {picked === "stroop" && (
           <>
-            <BackBtn onClick={() => setPicked(null)} />
+            <BackBtn onClick={goHome} />
             <h2 className="home-game-title">Stroop Test</h2>
             <p className="home-steps">Tap the <b>color of the ink</b> — not the word! Trains focus.</p>
             <div className="home-howto">

--- a/src/styles.css
+++ b/src/styles.css
@@ -175,6 +175,7 @@
   transition:transform .22s ease, border-color .22s, box-shadow .3s;
   text-align:center;
   color:var(--ink);
+  text-decoration:none;
   position:relative;
   overflow:hidden;
 }

--- a/src/utils/gameCatalog.js
+++ b/src/utils/gameCatalog.js
@@ -182,6 +182,30 @@ export const GAMES = [
   },
 ];
 
+export const GAME_ROUTES = {
+  simon: "simon-says",
+  math: "math-sprint",
+  memory: "memory-match",
+  twenty48: "twenty48",
+  connect4: "connect-four",
+  spatial: "shape-fit",
+  gomoku: "gomoku",
+  reversi: "reversi",
+  battleship: "battleship",
+  word: "word-scramble",
+  stroop: "stroop-test",
+};
+
+export function getGameRoute(id) {
+  return GAME_ROUTES[id] || id;
+}
+
+export function getGameIdFromRoute(route) {
+  const normalized = (route || "").toLowerCase();
+  const match = Object.entries(GAME_ROUTES).find(([, slug]) => slug === normalized);
+  return match ? match[0] : null;
+}
+
 /** Filter helpers */
 export function filterGames({ ageGroup = "all", category = "all", query = "" } = {}) {
   const q = query.trim().toLowerCase();

--- a/tests/gameCatalog.test.js
+++ b/tests/gameCatalog.test.js
@@ -1,0 +1,30 @@
+import {
+  GAMES,
+  GAME_ROUTES,
+  getGameRoute,
+  getGameIdFromRoute,
+} from "../src/utils/gameCatalog.js";
+
+test("every game id round-trips through its route slug", () => {
+  for (const game of GAMES) {
+    const route = getGameRoute(game.id);
+    expect(getGameIdFromRoute(route)).toBe(game.id);
+  }
+});
+
+test("every game has a route mapping", () => {
+  for (const game of GAMES) {
+    expect(GAME_ROUTES[game.id]).toBeTruthy();
+  }
+});
+
+test("route lookups are case-insensitive", () => {
+  const [id, slug] = Object.entries(GAME_ROUTES)[0];
+  expect(getGameIdFromRoute(slug.toUpperCase())).toBe(id);
+});
+
+test("unknown or empty routes resolve to null", () => {
+  expect(getGameIdFromRoute("nonexistent")).toBeNull();
+  expect(getGameIdFromRoute("")).toBeNull();
+  expect(getGameIdFromRoute(undefined)).toBeNull();
+});


### PR DESCRIPTION
Salvages the genuinely useful part of #38 onto current `main`, dropping the noise that made #38 unmergeable.

## What this adds
- **Deep-linkable games** — each game is reachable at `#/games/<slug>` (e.g. `#/games/connect-four`). Browser back/forward works via a `hashchange` listener that keeps the selected game in sync.
- **Real links** — game cards are now `<a href>` elements instead of `<button>`, so they're shareable, keyboard-navigable, and SEO-friendly. Added `text-decoration:none` to preserve the card look.
- **Route helpers** — `GAME_ROUTES` + `getGameRoute`/`getGameIdFromRoute` in `gameCatalog.js`, with a new test covering round-trips, full coverage, case-insensitivity, and unknown-route handling.

## What was dropped from #38
- `.understand-anything/` tool-cache files and rebuilt `dist/` artifacts (noise)
- An unrelated **regression** that deleted the "Rocket Launch" spatial puzzle from `spatialHelpers.js` — that puzzle exists on `main` and is kept intact here

## Validation
- `npm run lint` — clean (0 errors)
- `npm test` — 36 passing (8 suites)
- `npm run build` — succeeds

Replaces #38.